### PR TITLE
Introducing guaranteed memory wipe

### DIFF
--- a/Source/Core/argon2-core.cpp
+++ b/Source/Core/argon2-core.cpp
@@ -10,14 +10,16 @@
 
 using namespace std;
 
+/*For memory wiping*/
 #ifdef _MSC_VER
 #include "windows.h"
 #include "winbase.h" //For SecureZeroMemory
-#define VC_GE_2005( version )		( version >= 1400 )
 #endif
 #if defined __STDC_LIB_EXT1__
 #define __STDC_WANT_LIB_EXT1__ 1
 #endif
+#define VC_GE_2005( version )		( version >= 1400 )
+
 
 #include <inttypes.h>
 #include <vector>

--- a/Source/Core/argon2-core.cpp
+++ b/Source/Core/argon2-core.cpp
@@ -13,6 +13,7 @@ using namespace std;
 #ifdef _MSC_VER
 #include "windows.h"
 #include "winbase.h" //For SecureZeroMemory
+#define VC_GE_2005( version )		( version >= 1400 )
 #endif
 #if defined __STDC_LIB_EXT1__
 #define __STDC_WANT_LIB_EXT1__ 1
@@ -72,7 +73,7 @@ int AllocateMemory(block **memory, uint32_t m_cost) {
 
 static inline void NOT_OPTIMIZED secure_wipe_memory( void *v, size_t n )
 {
-#if defined _MSC_VER
+#if defined  (_MSC_VER ) &&  VC_GE_2005( _MSC_VER )
     SecureZeroMemory(v,n);
 #elif defined memset_s
     memset_s(v, n);

--- a/Source/Core/argon2-core.cpp
+++ b/Source/Core/argon2-core.cpp
@@ -31,7 +31,22 @@ using namespace std;
 #include "blake2.h"
 #include "blake2-impl.h"
 
- static void* (* const volatile memset_sec)(void*, int, size_t) = &memset;
+ #if defined(__clang__)
+#if __has_attribute(optnone)
+#define NOT_OPTIMIZED __attribute__((optnone))
+#endif
+#elif defined(__GNUC__)
+#define GCC_VERSION (__GNUC__ * 10000 \
+                    + __GNUC_MINOR__ * 100 \
+                    + __GNUC_PATCHLEVEL__)
+#if GCC_VERSION >= 40400
+ #define NOT_OPTIMIZED __attribute__((optimize("O0")))
+#endif
+#else 
+#define NOT_OPTIMIZED
+#endif
+
+static void* (* const volatile memset_sec)(void*, int, size_t) = &memset;
 
 
 block operator^(const block& l, const block& r) {
@@ -55,7 +70,7 @@ int AllocateMemory(block **memory, uint32_t m_cost) {
 * @param s Memory size in bytes
 */
 
-static inline void secure_wipe_memory( void *v, size_t n )
+static inline void NOT_OPTIMIZED secure_wipe_memory( void *v, size_t n )
 {
 #if defined _MSC_VER
     SecureZeroMemory(v,n);

--- a/Source/Core/argon2-core.h
+++ b/Source/Core/argon2-core.h
@@ -231,7 +231,7 @@ void FillSegment(const Argon2_instance_t* instance, Argon2_position_t position);
  * Function that fills the entire memory t_cost times based on the first two blocks in each lane
  * @param instance Pointer to the current instance
  */
-void FillMemory(const Argon2_instance_t* instance);
+void FillMemoryBlocks(const Argon2_instance_t* instance);
 
 
 /*

--- a/Source/Test/argon2-test.cpp
+++ b/Source/Test/argon2-test.cpp
@@ -121,7 +121,7 @@ void Benchmark() {
     memset(one_array, 1, 256);
     std::vector<uint32_t> thread_test = {1, 2, 4, 6, 8, 16};
 
-    for (uint32_t m_cost = (uint32_t) 1 << 3; m_cost <= (uint32_t) 1 << 19; m_cost *= 2) {
+    for (uint32_t m_cost = (uint32_t) 1 << 3; m_cost <= (uint32_t) 1 << 22; m_cost *= 2) {
         for (uint32_t thread_n : thread_test) {
 
 #ifdef _MEASURE
@@ -132,7 +132,7 @@ void Benchmark() {
             start_cycles = __rdtscp(&ui1);
 #endif
 
-            Argon2_Context context(out, outlen, zero_array, inlen, one_array, saltlen, NULL, 0, NULL, 0, t_cost, m_cost, thread_n);
+            Argon2_Context context(out, outlen, zero_array, inlen, one_array, saltlen, NULL, 0, NULL, 0, t_cost, m_cost, thread_n,NULL,NULL,false,false, false);
             Argon2d(&context);
 
 #ifdef _MEASURE


### PR DESCRIPTION
Memset can be optimized away by the compilers. Calls to memset are replaced with calls to a dedicated function, which clears the memory as follows:
- Using SecureZeroMemory in Windows
- Using memset_s (C11 Annex K) where available
- Using explicit_bzero in OpenBSD
- Using volatile function pointer (to memset) otherwise
- In addition, no optimization directives precede this function call
